### PR TITLE
Fix condition expectations in prevision of testthat breaking change

### DIFF
--- a/tests/testthat/test-wkb.R
+++ b/tests/testthat/test-wkb.R
@@ -47,12 +47,12 @@ test_that("as_wkb() works", {
 
 test_that("parse_wkb() works", {
   x <- wkt_translate_wkb("POINT (40 10)", endian = 1)
-  parsed <- expect_silent(parse_wkb(x))
+  expect_silent(parsed <- parse_wkb(x))
   expect_false(is.na(parsed))
   expect_null(attr(parsed, "problems"))
 
   x[[1]][2] <- as.raw(0xff)
-  parsed <- expect_warning(parse_wkb(x), "Encountered 1 parse problem")
+  expect_warning(parsed <- parse_wkb(x), "Encountered 1 parse problem")
   expect_true(is.na(parsed))
   expect_s3_class(attr(parsed, "problems"), "data.frame")
   expect_identical(nrow(attr(parsed, "problems")), 1L)

--- a/tests/testthat/test-wkt.R
+++ b/tests/testthat/test-wkt.R
@@ -34,12 +34,12 @@ test_that("as_wkt() works", {
 
 test_that("parse_wkt() works", {
   x <- "POINT (40 10)"
-  parsed <- expect_silent(parse_wkt(x))
+  expect_silent(parsed <- parse_wkt(x))
   expect_false(is.na(parsed))
   expect_null(attr(parsed, "problems"))
 
   x <- "POINT ENTPY"
-  parsed <- expect_warning(parse_wkt(x), "Encountered 1 parse problem")
+  expect_warning(parsed <- parse_wkt(x), "Encountered 1 parse problem")
   expect_true(is.na(parsed))
   expect_s3_class(attr(parsed, "problems"), "data.frame")
   expect_identical(nrow(attr(parsed, "problems")), 1L)


### PR DESCRIPTION
We are planning a breaking change to the condition expectations in testthat release (see NEWS item in https://github.com/r-lib/testthat/pull/1401). This PR implements a preventive fix that works with and without the breaking change.

There is no hurry to get this fix on CRAN since we are skipping one released version of testthat before going through with the change.