### PR TITLE
Write dimension when exporting EMPTY to WKT

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -16,6 +16,8 @@
   geometries to sf (#135).
 * `wk_plot()` now plots `NULL`/`NA` geometries and mixed geometry types
   more reliably (#142, #143, #149).
+* Exported EMPTY geometries to well-known text now include dimension
+  (e.g., `POINT Z EMPTY`) (#141, #150).
 
 # wk 0.6.0
 

--- a/src/wkt-writer.cpp
+++ b/src/wkt-writer.cpp
@@ -142,11 +142,11 @@ public:
             return this->error(err.str().c_str());
         }
 
-        if ((meta->size != 0) &&(meta->flags & WK_FLAG_HAS_Z) && (meta->flags & WK_FLAG_HAS_M)) {
+        if ((meta->flags & WK_FLAG_HAS_Z) && (meta->flags & WK_FLAG_HAS_M)) {
             out << "ZM ";
-        } else if ((meta->size != 0) && (meta->flags & WK_FLAG_HAS_Z)) {
+        } else if ((meta->flags & WK_FLAG_HAS_Z)) {
             out << "Z ";
-        } else if ((meta->size != 0) && (meta->flags & WK_FLAG_HAS_M)) {
+        } else if ((meta->flags & WK_FLAG_HAS_M)) {
             out << "M ";
         }
     }
@@ -165,7 +165,7 @@ public:
     if (ring_id > 0) {
       out << ", ";
     }
-    
+
     out << "(";
     return WK_CONTINUE;
   }
@@ -229,9 +229,9 @@ public:
 
 class WKTFormatHandler: public WKTWriterHandler {
 public:
-  WKTFormatHandler(int precision, bool trim, int max_coords): 
-    WKTWriterHandler(precision, trim), 
-    current_coords(0), 
+  WKTFormatHandler(int precision, bool trim, int max_coords):
+    WKTWriterHandler(precision, trim),
+    current_coords(0),
     max_coords(max_coords) {}
 
   int feature_start(const wk_vector_meta_t* meta, R_xlen_t feat_id) {

--- a/tests/testthat/test-handle-xy.R
+++ b/tests/testthat/test-handle-xy.R
@@ -7,16 +7,16 @@ test_that("wk_handle.wk_xy() works", {
 
   expect_identical(
     wk_handle(xyz(c(NA, 2, 3, NA), c(NA, NA, 4, 5), c(NA, NA, NA, NA)), wkt_writer()),
-    wkt(c("POINT EMPTY", "POINT Z (2 nan nan)", "POINT Z (3 4 nan)", "POINT Z (nan 5 nan)"))
+    wkt(c("POINT Z EMPTY", "POINT Z (2 nan nan)", "POINT Z (3 4 nan)", "POINT Z (nan 5 nan)"))
   )
 
   expect_identical(
     wk_handle(xym(c(NA, 2, 3, NA), c(NA, NA, 4, 5), c(NA, NA, NA, NA)), wkt_writer()),
-    wkt(c("POINT EMPTY", "POINT M (2 nan nan)", "POINT M (3 4 nan)", "POINT M (nan 5 nan)"))
+    wkt(c("POINT M EMPTY", "POINT M (2 nan nan)", "POINT M (3 4 nan)", "POINT M (nan 5 nan)"))
   )
 
   expect_identical(
     wk_handle(xyzm(c(NA, 2, 3, NA), c(NA, NA, 4, 5), c(NA, NA, NA, NA), c(NA, rep(1, 3))), wkt_writer()),
-    wkt(c("POINT EMPTY", "POINT ZM (2 nan nan 1)", "POINT ZM (3 4 nan 1)", "POINT ZM (nan 5 nan 1)"))
+    wkt(c("POINT ZM EMPTY", "POINT ZM (2 nan nan 1)", "POINT ZM (3 4 nan 1)", "POINT ZM (nan 5 nan 1)"))
   )
 })


### PR DESCRIPTION
Fixes #141.

``` r
unclass(wk::as_wkt(wk::as_wkb("POLYGON ZM EMPTY")))
#> [1] "POLYGON ZM EMPTY"
```

<sup>Created on 2022-09-18 by the [reprex package](https://reprex.tidyverse.org) (v2.0.1)</sup>