### PR TITLE
Fix ring closing

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -18,6 +18,8 @@
   more reliably (#142, #143, #149).
 * Exported EMPTY geometries to well-known text now include dimension
   (e.g., `POINT Z EMPTY`) (#141, #150).
+* Fixed bug where `wk_polygon()` doubled some points when the input contained
+  closed rings (#134, #151).
 
 # wk 0.6.0
 

--- a/src/make-polygon-filter.c
+++ b/src/make-polygon-filter.c
@@ -130,6 +130,11 @@ int wk_polygon_filter_coord(const wk_meta_t* meta, const double* coord, uint32_t
   polygon_filter_t* polygon_filter = (polygon_filter_t*) handler_data;
   int result;
 
+  // maybe need to close the ring before starting a new feature/ring
+  if (polygon_filter->is_new_ring && polygon_filter->feature_id > 0) {
+    HANDLE_OR_RETURN(wk_ring_end(polygon_filter));
+  }
+
   // We always need to keep a copy of the last coordinate because we
   // need to check for closed rings and the ring end method gets called
   // at the *next* coordinate where there's a new feature.
@@ -138,11 +143,6 @@ int wk_polygon_filter_coord(const wk_meta_t* meta, const double* coord, uint32_t
     ((meta->flags & WK_FLAG_HAS_M) != 0);
   memset(polygon_filter->last_coord, 0, 4 * sizeof(double));
   memcpy(polygon_filter->last_coord, coord, polygon_filter->last_coord_size * sizeof(double));
-
-  // maybe need to close the ring before starting a new feature/ring
-  if (polygon_filter->is_new_ring && polygon_filter->feature_id > 0) {
-    HANDLE_OR_RETURN(wk_ring_end(polygon_filter));
-  }
 
   if (polygon_filter->is_new_feature) {
     if (polygon_filter->feature_id > 0) {

--- a/tests/testthat/test-make.R
+++ b/tests/testthat/test-make.R
@@ -143,6 +143,52 @@ test_that("wk_polygon() works", {
   )
 })
 
+test_that("wk_polygon() closes rings where appropriate", {
+  rings_closed <- wkt(
+    c(
+      "LINESTRING (0 0, 1 0, 1 1, 0 1, 0 0)",
+      "LINESTRING (0 0, 0 -1, -1 -1, -1 0, 0 0)",
+      "LINESTRING (1 1, 2 1, 2 2, 1 2, 1 1)",
+      "LINESTRING (2 2, 3 2, 3 3, 2 3, 2 2)"
+    )
+  )
+
+  vertices_closed <- wk_vertices(rings_closed)
+  expect_identical(
+    wk_polygon(vertices_closed, rep(1:4, each = 5)),
+    wkt(
+      c(
+        "POLYGON ((0 0, 1 0, 1 1, 0 1, 0 0))",
+        "POLYGON ((0 0, 0 -1, -1 -1, -1 0, 0 0))",
+        "POLYGON ((1 1, 2 1, 2 2, 1 2, 1 1))",
+        "POLYGON ((2 2, 3 2, 3 3, 2 3, 2 2))"
+      )
+    )
+  )
+
+  rings_open <- wkt(
+    c(
+      "LINESTRING (0 0, 1 0, 1 1, 0 1)",
+      "LINESTRING (0 0, 0 -1, -1 -1, -1 0)",
+      "LINESTRING (1 1, 2 1, 2 2, 1 2)",
+      "LINESTRING (2 2, 3 2, 3 3, 2 3)"
+    )
+  )
+
+  vertices_open <- wk_vertices(rings_open)
+  expect_identical(
+    wk_polygon(vertices_open, rep(1:4, each = 4)),
+    wkt(
+      c(
+        "POLYGON ((0 0, 1 0, 1 1, 0 1, 0 0))",
+        "POLYGON ((0 0, 0 -1, -1 -1, -1 0, 0 0))",
+        "POLYGON ((1 1, 2 1, 2 2, 1 2, 1 1))",
+        "POLYGON ((2 2, 3 2, 3 3, 2 3, 2 2))"
+      )
+    )
+  )
+})
+
 test_that("wk_polygon() propagates geodesic", {
   expect_identical(
     wk_polygon(wkt("POLYGON ((40 40, 20 45, 45 30, 40 40))"), geodesic = TRUE),


### PR DESCRIPTION
Fixes #134.

``` r
poly_base <- wk::wkt(
  c(
    "POLYGON ZM ((0 0 2 3, 1 0 2 3, 1 1 2 3, 0 1 2 3, 0 0 2 3))",
    "POLYGON ZM ((0 0 2 3, 0 -1 2 3, -1 -1 2 3, -1 0 2 3, 0 0 2 3))",
    "POLYGON ZM ((1 1 2 3, 2 1 2 3, 2 2 2 3, 1 2 2 3, 1 1 2 3))",
    "POLYGON ZM ((2 2 2 3, 3 2 2 3, 3 3 2 3, 2 3 2 3, 2 2 2 3))"
  )
)
(coords_base <- wk::wk_vertices(poly_base))
#> <wk_wkt[20]>
#>  [1] POINT ZM (0 0 2 3)   POINT ZM (1 0 2 3)   POINT ZM (1 1 2 3)  
#>  [4] POINT ZM (0 1 2 3)   POINT ZM (0 0 2 3)   POINT ZM (0 0 2 3)  
#>  [7] POINT ZM (0 -1 2 3)  POINT ZM (-1 -1 2 3) POINT ZM (-1 0 2 3) 
#> [10] POINT ZM (0 0 2 3)   POINT ZM (1 1 2 3)   POINT ZM (2 1 2 3)  
#> [13] POINT ZM (2 2 2 3)   POINT ZM (1 2 2 3)   POINT ZM (1 1 2 3)  
#> [16] POINT ZM (2 2 2 3)   POINT ZM (3 2 2 3)   POINT ZM (3 3 2 3)  
#> [19] POINT ZM (2 3 2 3)   POINT ZM (2 2 2 3)

poly <- wk::wk_polygon(
  coords_base,
  feature_id = rep(1:4, each = 5)
)

as.character(wk::as_wkt(poly))
#> [1] "POLYGON ZM ((0 0 2 3, 1 0 2 3, 1 1 2 3, 0 1 2 3, 0 0 2 3))"    
#> [2] "POLYGON ZM ((0 0 2 3, 0 -1 2 3, -1 -1 2 3, -1 0 2 3, 0 0 2 3))"
#> [3] "POLYGON ZM ((1 1 2 3, 2 1 2 3, 2 2 2 3, 1 2 2 3, 1 1 2 3))"    
#> [4] "POLYGON ZM ((2 2 2 3, 3 2 2 3, 3 3 2 3, 2 3 2 3, 2 2 2 3))"

wk::wk_vertices(poly)
#> <wk_wkt[20]>
#>  [1] POINT ZM (0 0 2 3)   POINT ZM (1 0 2 3)   POINT ZM (1 1 2 3)  
#>  [4] POINT ZM (0 1 2 3)   POINT ZM (0 0 2 3)   POINT ZM (0 0 2 3)  
#>  [7] POINT ZM (0 -1 2 3)  POINT ZM (-1 -1 2 3) POINT ZM (-1 0 2 3) 
#> [10] POINT ZM (0 0 2 3)   POINT ZM (1 1 2 3)   POINT ZM (2 1 2 3)  
#> [13] POINT ZM (2 2 2 3)   POINT ZM (1 2 2 3)   POINT ZM (1 1 2 3)  
#> [16] POINT ZM (2 2 2 3)   POINT ZM (3 2 2 3)   POINT ZM (3 3 2 3)  
#> [19] POINT ZM (2 3 2 3)   POINT ZM (2 2 2 3)
```

<sup>Created on 2022-09-18 by the [reprex package](https://reprex.tidyverse.org) (v2.0.1)</sup>