### PR TITLE
Don't allocate z or m members of an xy unless they're needed

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -22,6 +22,8 @@
   closed rings (#134, #151).
 * Fixed bug where `wk_count()` exposed uninitialized values for empty input
   (#139, #153).
+* The `xy_writer()` now opportunistically avoids allocating vectors for Z
+  or M values unless they are actually needed (#131, #154).
 
 # wk 0.6.0
 

--- a/tests/testthat/test-xy-writer.R
+++ b/tests/testthat/test-xy-writer.R
@@ -45,3 +45,29 @@ test_that("xy_writer() works for a vector of indeterminate length", {
     wk_handle(long_xy, xy_writer())
   )
 })
+
+test_that("xy_writer() works with zm dimensions", {
+  points_xyzm <- xyzm(1:10, 11:20, 21:30, 31:40)
+  expect_identical(
+    wk_handle(points_xyzm, xy_writer()),
+    points_xyzm
+  )
+
+  long_xyzm <- as_wkt(xyzm(runif(2048), runif(2048), runif(2048), runif(2048)))
+  expect_identical(
+    handle_wkt_without_vector_size(long_xyzm, xy_writer()),
+    wk_handle(long_xyzm, xy_writer())
+  )
+})
+
+test_that("xy_writer() fills unused dimensions with NA", {
+  points_xy <- xy(1:10, 11:20)
+  points_xyzm <- xyzm(1:10, 11:20, 21:30, 31:40)
+  expect_identical(
+    wk_handle(c(as_wkb(points_xy), as_wkb(points_xyzm)), xy_writer()),
+    c(
+      xyzm(1:10, 11:20, NA, NA),
+      points_xyzm
+    )
+  )
+})


### PR DESCRIPTION
Fixes #131.

Before:

``` r
library(wk)

many_points <- as_wkb(xy(runif(1e6), runif(1e6)))
bench::mark(as_xy(many_points))
#> # A tibble: 1 × 6
#>   expression              min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr>         <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 as_xy(many_points)     67ms   67.3ms      14.9    30.6MB     37.2
```

<sup>Created on 2022-09-21 by the [reprex package](https://reprex.tidyverse.org) (v2.0.1)</sup>

After:

``` r
library(wk)

many_points <- as_wkb(xy(runif(1e6), runif(1e6)))
bench::mark(as_xy(many_points))
#> # A tibble: 1 × 6
#>   expression              min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr>         <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 as_xy(many_points)   24.6ms   25.1ms      39.8    15.3MB     62.5
```

<sup>Created on 2022-09-21 by the [reprex package](https://reprex.tidyverse.org) (v2.0.1)</sup>