### PR TITLE
Explicitly throw error instead of rely on NextMethod()

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # wk (development version)
 
+* Fix implicit reliance on error `as.data.frame.default()`,
+  which no longer occurs in r-devel (#166).
+
 # wk 0.7.0
 
 * Remove legacy headers that are no longer used by any downstream package

--- a/R/wk-vctr.R
+++ b/R/wk-vctr.R
@@ -106,7 +106,7 @@ rep_len.wk_vctr <- function(x, ...) {
 #' @export
 as.data.frame.wk_vctr <- function(x, ..., optional = FALSE) {
   if (!optional) {
-    NextMethod()
+    stop(sprintf("cannot coerce object of tyoe '%s' to data.frame", class()))
   } else {
     new_data_frame(list(x))
   }

--- a/R/wk-vctr.R
+++ b/R/wk-vctr.R
@@ -106,7 +106,7 @@ rep_len.wk_vctr <- function(x, ...) {
 #' @export
 as.data.frame.wk_vctr <- function(x, ..., optional = FALSE) {
   if (!optional) {
-    stop(sprintf("cannot coerce object of tyoe '%s' to data.frame", class()))
+    stop(sprintf("cannot coerce object of tyoe '%s' to data.frame", class(x)[1]))
   } else {
     new_data_frame(list(x))
   }


### PR DESCRIPTION
Fixes a CRAN check warning, since as.data.frame.default() has changed in r-devel().