### PR TITLE
Use .empty() instead of checking .size()==0

### DIFF
--- a/src/internal/buffered-reader.hpp
+++ b/src/internal/buffered-reader.hpp
@@ -381,7 +381,7 @@ private:
   }
 
   static std::string quote(std::string input) {
-    if (input.size() == 0) {
+    if (input.empty()) {
       return "end of input";
     } else {
       std::stringstream stream;

--- a/src/wkt-writer.cpp
+++ b/src/wkt-writer.cpp
@@ -104,15 +104,15 @@ public:
   }
 
   int geometry_start(const wk_meta_t* meta, uint32_t part_id) {
-    if ((part_id != 0) && (this->stack.size() > 0)) {
+    if ((part_id != 0) && !this->stack.empty()) {
       out << ", ";
     }
 
-    if ((meta->srid != WK_SRID_NONE) && (this->stack.size() == 0)) {
+    if ((meta->srid != WK_SRID_NONE) && this->stack.empty()) {
       out << "SRID=" << meta->srid << ";";
     }
 
-    if ((this->stack.size() == 0) || this->isNestingCollection()) {
+    if (this->stack.empty() || this->isNestingCollection()) {
         switch (meta->geometry_type) {
         case WK_POINT:
             out << "POINT ";


### PR DESCRIPTION
See https://releases.llvm.org/5.0.1/tools/clang/tools/extra/docs/clang-tidy/checks/readability-container-size-empty.html