### PR TITLE
avoid overloading name 'feat_id'

### DIFF
--- a/src/wkt-writer.cpp
+++ b/src/wkt-writer.cpp
@@ -92,7 +92,7 @@ public:
     return WK_CONTINUE;
   }
 
-  virtual int feature_start(const wk_vector_meta_t* meta, R_xlen_t feat_id) {
+  virtual int feature_start(const wk_vector_meta_t* meta, R_xlen_t feature_id) {
     out.str("");
     this->stack.clear();
     return WK_CONTINUE;
@@ -200,7 +200,7 @@ public:
     return WK_CONTINUE;
   }
 
-  int feature_end(const wk_vector_meta_t* meta, R_xlen_t feat_id) {
+  int feature_end(const wk_vector_meta_t* meta, R_xlen_t feature_id) {
     current_item = this->out.str();
     this->resultAppend(current_item);
     return WK_CONTINUE;
@@ -234,9 +234,9 @@ public:
     current_coords(0),
     max_coords(max_coords) {}
 
-  int feature_start(const wk_vector_meta_t* meta, R_xlen_t feat_id) {
+  int feature_start(const wk_vector_meta_t* meta, R_xlen_t feature_id) {
     this->current_coords = 0;
-    return WKTWriterHandler::feature_start(meta, feat_id);
+    return WKTWriterHandler::feature_start(meta, feature_id);
   }
 
   int null_feature() {


### PR DESCRIPTION
Pointed out by the `-Wshadow-field` flag, IIUC the issue is the class member `feat_id`:

https://github.com/paleolimbot/wk/blob/99e842749dea9ef11a08a198357e1752117442e3/src/wkt-writer.cpp#L13

That can make it slightly ambiguous which `feat_id` is intended in a given instance; renamed as `feat_id` to help clarify things.