### PR TITLE
Fix `part_id` for `wk_collection_filter_geometry_start()`

### DIFF
--- a/src/make-collection-filter.c
+++ b/src/make-collection-filter.c
@@ -128,8 +128,8 @@ int wk_collection_filter_geometry_start(const wk_meta_t* meta, uint32_t part_id,
   }
 
   if (part_id == WK_PART_ID_NONE) {
-    part_id = collection_filter->part_id;
     collection_filter->part_id += inc_part_id;
+    part_id = collection_filter->part_id;
   }
 
   return collection_filter->next->geometry_start(meta, part_id, collection_filter->next->handler_data);


### PR DESCRIPTION
Hi Dewey!

An issue seems to have popped up with wk v0.8.0. It appears  `wk_collection_filter_geometry_start()` needs a minor change to order of operations to make sure the now-properly-incremented `part_id` is passed to next `geometry_start()`

With current CRAN version we get the following
``` r
# wk 0.8.0
p <- sf::st_as_sf(
  data.frame(x = -119.72330, y = 36.92204),
  coords = c('x', 'y'),
  crs = 4326
)
p2 <- rbind(p, p)
pm <- sf::st_combine(p2)

x <- wk::wk_collection(p2)
y <- wk::wk_collection(wk::as_wkt(p2))
z <- wk::wk_collection(pm)

x
#> Geometry set for 1 feature 
#> Geometry type: GEOMETRYCOLLECTION
#> Dimension:     XY
#> Bounding box:  xmin: -119.7233 ymin: 36.92204 xmax: -119.7233 ymax: 36.92204
#> Geodetic CRS:  WGS 84
#> GEOMETRYCOLLECTION (POINT (-119.7233 36.92204),...
y
#> <wk_wkt[1] with CRS=EPSG:4326>
#> [1] GEOMETRYCOLLECTION (POINT (-119.7233 36.92204)!!! Expected ',' or ')' but found 'POINT' at byte 46
z
#> Geometry set for 1 feature 
#> Geometry type: GEOMETRYCOLLECTION
#> Dimension:     XY
#> Bounding box:  xmin: -119.7233 ymin: 36.92204 xmax: -119.7233 ymax: 36.92204
#> Geodetic CRS:  WGS 84
#> GEOMETRYCOLLECTION (MULTIPOINT ((-119.7233 36.9...
```

Note the error message: `!!! Expected ',' or ')' but found 'POINT' at byte 46` when creating a collection from wk_wkt object.

After the tiny fix in this PR we get:
``` r
p <- sf::st_as_sf(
  data.frame(x = -119.72330, y = 36.92204),
  coords = c('x', 'y'),
  crs = 4326
)
p2 <- rbind(p, p)
pm <- sf::st_combine(p2)

x <- wk::wk_collection(p2)
y <- wk::wk_collection(wk::as_wkt(p2))
z <- wk::wk_collection(pm)

x
#> Geometry set for 1 feature 
#> Geometry type: GEOMETRYCOLLECTION
#> Dimension:     XY
#> Bounding box:  xmin: -119.7233 ymin: 36.92204 xmax: -119.7233 ymax: 36.92204
#> Geodetic CRS:  WGS 84
#> GEOMETRYCOLLECTION (POINT (-119.7233 36.92204),...
y
#> <wk_wkt[1] with CRS=EPSG:4326>
#> [1] GEOMETRYCOLLECTION (POINT (-119.7233 36.92204), POINT (-119.7233 36.92204))
z
#> Geometry set for 1 feature 
#> Geometry type: GEOMETRYCOLLECTION
#> Dimension:     XY
#> Bounding box:  xmin: -119.7233 ymin: 36.92204 xmax: -119.7233 ymax: 36.92204
#> Geodetic CRS:  WGS 84
#> GEOMETRYCOLLECTION (MULTIPOINT ((-119.7233 36.9...
```

Let me know what you think! 