### PR TITLE
Add `promote_multi` to `sfc_writer()`

### DIFF
--- a/R/sfc-writer.R
+++ b/R/sfc-writer.R
@@ -1,6 +1,6 @@
 
 #' @rdname wk_writer
 #' @export
-sfc_writer <- function() {
-  new_wk_handler(.Call(wk_c_sfc_writer_new), "wk_sfc_writer")
+sfc_writer <- function(promote_multi = FALSE) {
+  new_wk_handler(.Call(wk_c_sfc_writer_new, as.logical(promote_multi)[1]), "wk_sfc_writer")
 }

--- a/R/writer.R
+++ b/R/writer.R
@@ -17,6 +17,9 @@
 #' @param generic Use `TRUE` to obtain a writer that can write all geometry
 #'   types.
 #' @param buffer_size Control the initial buffer size used when writing WKB.
+#' @param promote_multi Use TRUE to promote all simple geometries to a multi
+#'   type when reading to sfc. This is useful to increase the likelihood that
+#'   the sfc will contain a single geometry type.
 #' @param ... Passed to the writer constructor.
 #'
 #' @return A [wk_handler][wk_handle].

--- a/man/wk_writer.Rd
+++ b/man/wk_writer.Rd
@@ -19,7 +19,7 @@
 
 \method{wk_writer}{sf}(handleable, ...)
 
-sfc_writer()
+sfc_writer(promote_multi = FALSE)
 
 wkb_writer(buffer_size = 2048L, endian = NA_integer_)
 
@@ -42,6 +42,10 @@ xy_writer()
 \code{\link[=rct]{rct()}}, or \code{\link[sf:sfc]{sf::st_sfc()}}) for which \code{\link[=wk_handle]{wk_handle()}} is defined.}
 
 \item{...}{Passed to the writer constructor.}
+
+\item{promote_multi}{Use TRUE to promote all simple geometries to a multi
+type when reading to sfc. This is useful to increase the likelihood that
+the sfc will contain a single geometry type.}
 
 \item{buffer_size}{Control the initial buffer size used when writing WKB.}
 

--- a/src/init.c
+++ b/src/init.c
@@ -25,7 +25,7 @@ SEXP wk_c_meta_handler_new(void);
 SEXP wk_c_vector_meta_handler_new(void);
 SEXP wk_c_orient_filter_new(SEXP handler_xptr, SEXP direction);
 SEXP wk_c_problems_handler_new(void);
-SEXP wk_c_sfc_writer_new(void);
+SEXP wk_c_sfc_writer_new(SEXP promote_multi_sexp);
 SEXP wk_c_trans_affine_new(SEXP trans_matrix);
 SEXP wk_c_trans_affine_as_matrix(SEXP trans_xptr);
 SEXP wk_c_trans_explicit_new(SEXP xy, SEXP use_z, SEXP use_m);
@@ -63,7 +63,7 @@ static const R_CallMethodDef CallEntries[] = {
   {"wk_c_vector_meta_handler_new", (DL_FUNC) &wk_c_vector_meta_handler_new, 0},
   {"wk_c_orient_filter_new", (DL_FUNC) &wk_c_orient_filter_new, 2},
   {"wk_c_problems_handler_new", (DL_FUNC) &wk_c_problems_handler_new, 0},
-  {"wk_c_sfc_writer_new", (DL_FUNC) &wk_c_sfc_writer_new, 0},
+  {"wk_c_sfc_writer_new", (DL_FUNC) &wk_c_sfc_writer_new, 1},
   {"wk_c_trans_affine_new", (DL_FUNC) &wk_c_trans_affine_new, 1},
   {"wk_c_trans_affine_as_matrix", (DL_FUNC) &wk_c_trans_affine_as_matrix, 1},
   {"wk_c_trans_explicit_new", (DL_FUNC) &wk_c_trans_explicit_new, 3},

--- a/src/sfc-writer.c
+++ b/src/sfc-writer.c
@@ -205,10 +205,15 @@ SEXP sfc_writer_promote_multi(SEXP item, int geometry_type, uint32_t flags, uint
     }
     case WK_LINESTRING:
     case WK_POLYGON: {
-        SEXP result = PROTECT(Rf_allocVector(VECSXP, 1));
-        SET_VECTOR_ELT(result, 0, item);
-        UNPROTECT(1);
-        return result;
+        if (size > 0) {
+            SEXP result = PROTECT(Rf_allocVector(VECSXP, 1));
+            Rf_setAttrib(item, R_ClassSymbol, R_NilValue);
+            SET_VECTOR_ELT(result, 0, item);
+            UNPROTECT(1);
+            return result;
+        } else {
+            return Rf_allocVector(VECSXP, 0);
+        }
     }
 
     default:

--- a/tests/testthat/test-sfc-writer.R
+++ b/tests/testthat/test-sfc-writer.R
@@ -130,37 +130,37 @@ test_that("sfc_writer() works with promote_multi = TRUE", {
           "GEOMETRYCOLLECTION EMPTY"
         )
       ),
-      sfc_writer()
+      sfc_writer(promote_multi = TRUE)
     ),
     sf::st_sfc(
-      sf::st_point(), sf::st_linestring(), sf::st_polygon(),
+      sf::st_multipoint(), sf::st_multilinestring(), sf::st_multipolygon(),
       sf::st_multipoint(), sf::st_multilinestring(), sf::st_multipolygon(),
       sf::st_geometrycollection()
     )
   )
 
   expect_identical(
-    wk_handle(as_wkb("POINT (1 1)"), sfc_writer()),
-    sf::st_sfc(sf::st_point(c(1, 1)))
+    wk_handle(as_wkb("POINT (1 1)"), sfc_writer(promote_multi = TRUE)),
+    sf::st_sfc(sf::st_multipoint(matrix(c(1, 1), ncol = 2)))
   )
 
   expect_identical(
-    wk_handle(as_wkb("LINESTRING (1 2, 3 4)"), sfc_writer()),
-    sf::st_sfc(sf::st_linestring(rbind(c(1, 2), c(3, 4))))
+    wk_handle(as_wkb("LINESTRING (1 2, 3 4)"), sfc_writer(promote_multi = TRUE)),
+    sf::st_sfc(sf::st_multilinestring(list(rbind(c(1, 2), c(3, 4)))))
   )
 
   expect_identical(
-    wk_handle(as_wkb("POLYGON ((0 0, 0 1, 1 0, 0 0))"), sfc_writer()),
-    sf::st_sfc(sf::st_polygon(list(rbind(c(0, 0), c(0, 1), c(1, 0), c(0, 0)))))
+    wk_handle(as_wkb("POLYGON ((0 0, 0 1, 1 0, 0 0))"), sfc_writer(promote_multi = TRUE)),
+    sf::st_sfc(sf::st_multipolygon(list(list(rbind(c(0, 0), c(0, 1), c(1, 0), c(0, 0))))))
   )
 
   expect_identical(
-    wk_handle(as_wkb("MULTIPOINT ((1 2), (3 4))"), sfc_writer()),
+    wk_handle(as_wkb("MULTIPOINT ((1 2), (3 4))"), sfc_writer(promote_multi = TRUE)),
     sf::st_sfc(sf::st_multipoint(rbind(c(1, 2), c(3, 4))))
   )
 
   expect_identical(
-    wk_handle(as_wkb("MULTILINESTRING ((1 1, 2 2), (2 2, 3 4))"), sfc_writer()),
+    wk_handle(as_wkb("MULTILINESTRING ((1 1, 2 2), (2 2, 3 4))"), sfc_writer(promote_multi = TRUE)),
     sf::st_sfc(
       sf::st_multilinestring(
         list(rbind(c(1, 1), c(2, 2)), rbind(c(2, 2), c(3, 4)))
@@ -171,7 +171,7 @@ test_that("sfc_writer() works with promote_multi = TRUE", {
   expect_identical(
     wk_handle(
       as_wkb("MULTIPOLYGON (((0 0, 0 1, 1 0, 0 0)), ((0 0, 0 -2, -1 0, 0 0)))"),
-      sfc_writer()
+      sfc_writer(promote_multi = TRUE)
     ),
     sf::st_sfc(
       sf::st_multipolygon(
@@ -184,7 +184,10 @@ test_that("sfc_writer() works with promote_multi = TRUE", {
   )
 
   expect_identical(
-    wk_handle(as_wkb("GEOMETRYCOLLECTION (POINT (1 1), LINESTRING (1 1, 2 2))"), sfc_writer()),
+    wk_handle(
+      as_wkb("GEOMETRYCOLLECTION (POINT (1 1), LINESTRING (1 1, 2 2))"),
+      sfc_writer(promote_multi = TRUE)
+    ),
     sf::st_sfc(
       sf::st_geometrycollection(
         list(

--- a/tests/testthat/test-sfc-writer.R
+++ b/tests/testthat/test-sfc-writer.R
@@ -145,6 +145,21 @@ test_that("sfc_writer() works with promote_multi = TRUE", {
   )
 
   expect_identical(
+    wk_handle(as_wkb("POINT Z (1 1 2)"), sfc_writer(promote_multi = TRUE)),
+    sf::st_sfc(sf::st_multipoint(matrix(c(1, 1, 2), ncol = 3)))
+  )
+
+  expect_identical(
+    wk_handle(as_wkb("POINT M (1 1 2)"), sfc_writer(promote_multi = TRUE)),
+    sf::st_sfc(sf::st_multipoint(matrix(c(1, 1, 2), ncol = 3), dim = "XYM"))
+  )
+
+  expect_identical(
+    wk_handle(as_wkb("POINT ZM (1 1 2 3)"), sfc_writer(promote_multi = TRUE)),
+    sf::st_sfc(sf::st_multipoint(matrix(c(1, 1, 2, 3), ncol = 4)))
+  )
+
+  expect_identical(
     wk_handle(as_wkb("LINESTRING (1 2, 3 4)"), sfc_writer(promote_multi = TRUE)),
     sf::st_sfc(sf::st_multilinestring(list(rbind(c(1, 2), c(3, 4)))))
   )

--- a/tests/testthat/test-sfc-writer.R
+++ b/tests/testthat/test-sfc-writer.R
@@ -99,6 +99,103 @@ test_that("sfc_writer() works with fixed-length input", {
   )
 })
 
+test_that("sfc_writer() works with promote_multi = TRUE", {
+  skip_if_not_installed("sf")
+
+  # empties (equal because of NaN/NA difference for POINT)
+  expect_equal_ignore_na_nan(
+    wk_handle(
+      as_wkb(
+        c("POINT EMPTY", "LINESTRING EMPTY", "POLYGON EMPTY",
+          "MULTIPOINT EMPTY", "MULTILINESTRING EMPTY", "MULTIPOLYGON EMPTY",
+          "GEOMETRYCOLLECTION EMPTY"
+        )
+      ),
+      sfc_writer(promote_multi = TRUE)
+    ),
+    sf::st_sfc(
+      sf::st_multipoint(), sf::st_multilinestring(), sf::st_multipolygon(),
+      sf::st_multipoint(), sf::st_multilinestring(), sf::st_multipolygon(),
+      sf::st_geometrycollection()
+    )
+  )
+
+  # subtely different for WKT, since a point will fire zero coordinates
+  # whereas for WKB it will fire (NaN, NaN)
+  expect_equal_ignore_na_nan(
+    wk_handle(
+      as_wkt(
+        c("POINT EMPTY", "LINESTRING EMPTY", "POLYGON EMPTY",
+          "MULTIPOINT EMPTY", "MULTILINESTRING EMPTY", "MULTIPOLYGON EMPTY",
+          "GEOMETRYCOLLECTION EMPTY"
+        )
+      ),
+      sfc_writer()
+    ),
+    sf::st_sfc(
+      sf::st_point(), sf::st_linestring(), sf::st_polygon(),
+      sf::st_multipoint(), sf::st_multilinestring(), sf::st_multipolygon(),
+      sf::st_geometrycollection()
+    )
+  )
+
+  expect_identical(
+    wk_handle(as_wkb("POINT (1 1)"), sfc_writer()),
+    sf::st_sfc(sf::st_point(c(1, 1)))
+  )
+
+  expect_identical(
+    wk_handle(as_wkb("LINESTRING (1 2, 3 4)"), sfc_writer()),
+    sf::st_sfc(sf::st_linestring(rbind(c(1, 2), c(3, 4))))
+  )
+
+  expect_identical(
+    wk_handle(as_wkb("POLYGON ((0 0, 0 1, 1 0, 0 0))"), sfc_writer()),
+    sf::st_sfc(sf::st_polygon(list(rbind(c(0, 0), c(0, 1), c(1, 0), c(0, 0)))))
+  )
+
+  expect_identical(
+    wk_handle(as_wkb("MULTIPOINT ((1 2), (3 4))"), sfc_writer()),
+    sf::st_sfc(sf::st_multipoint(rbind(c(1, 2), c(3, 4))))
+  )
+
+  expect_identical(
+    wk_handle(as_wkb("MULTILINESTRING ((1 1, 2 2), (2 2, 3 4))"), sfc_writer()),
+    sf::st_sfc(
+      sf::st_multilinestring(
+        list(rbind(c(1, 1), c(2, 2)), rbind(c(2, 2), c(3, 4)))
+      )
+    )
+  )
+
+  expect_identical(
+    wk_handle(
+      as_wkb("MULTIPOLYGON (((0 0, 0 1, 1 0, 0 0)), ((0 0, 0 -2, -1 0, 0 0)))"),
+      sfc_writer()
+    ),
+    sf::st_sfc(
+      sf::st_multipolygon(
+        list(
+          list(rbind(c(0, 0), c(0, 1), c(1, 0), c(0, 0))),
+          list(rbind(c(0, 0), c(0, -2), c(-1, 0), c(0, 0)))
+        )
+      )
+    )
+  )
+
+  expect_identical(
+    wk_handle(as_wkb("GEOMETRYCOLLECTION (POINT (1 1), LINESTRING (1 1, 2 2))"), sfc_writer()),
+    sf::st_sfc(
+      sf::st_geometrycollection(
+        list(
+          sf::st_point(c(1, 1)),
+          sf::st_linestring(rbind(c(1, 1), c(2, 2)))
+        )
+      )
+    )
+  )
+})
+
 test_that("nested points are treated the same as top-level points", {
   skip_if_not_installed("sf")
 


### PR DESCRIPTION
This makes it much more likely that the resulting sfc will have a single output type (which may help it get used in stream reading, since stream reading gives a WKB vector).