### PR TITLE
Handle WKB POINT (nan nan) as EMPTY

### DIFF
--- a/tests/testthat/test-handle-wkt.R
+++ b/tests/testthat/test-handle-wkt.R
@@ -172,7 +172,7 @@ test_that("wkt_translate_wkb() works on NA", {
 test_that("wkt_translate_wkb() works on empty points", {
   expect_identical(
     wkb_translate_wkt(wkt_translate_wkb("POINT EMPTY")),
-    "POINT (nan nan)"
+    "POINT EMPTY"
   )
 })
 

--- a/tests/testthat/test-meta.R
+++ b/tests/testthat/test-meta.R
@@ -17,7 +17,7 @@ test_that("wk_meta() works", {
     wk_meta(as_wkb(c("POINT (1 2)", "POINT EMPTY", NA))),
     data.frame(
       geometry_type = c(1L, 1L, NA_integer_),
-      size = c(1L, 1L, NA_integer_),
+      size = c(1L, 0L, NA_integer_),
       has_z = c(FALSE, FALSE, NA),
       has_m = c(FALSE, FALSE, NA),
       srid = c(NA_integer_, NA_integer_, NA_integer_),

--- a/tests/testthat/test-pkg-sf.R
+++ b/tests/testthat/test-pkg-sf.R
@@ -70,7 +70,7 @@ test_that("conversion from sf to wkb works", {
   expect_s3_class(as_wkb(sfc), "wk_wkb")
   expect_identical(
     as.character(as_wkt(as_wkb(sfc))),
-    c("POINT (nan nan)", "POINT (0 1)")
+    c("POINT EMPTY", "POINT (0 1)")
   )
   expect_identical(wk_crs(as_wkb(sfc)), sf::st_crs(sfc))
 
@@ -84,7 +84,7 @@ test_that("conversion from sf to wkb works", {
   sf <- sf::st_as_sf(new_data_frame(list(geometry = sfc)))
   expect_identical(
     as.character(as_wkt(as_wkb(sf))),
-    c("POINT (nan nan)", "POINT (0 1)")
+    c("POINT EMPTY", "POINT (0 1)")
   )
   expect_identical(wk_crs(as_wkb(sf)), sf::st_crs(sf))
 })

--- a/tests/testthat/test-wkb.R
+++ b/tests/testthat/test-wkb.R
@@ -103,8 +103,8 @@ test_that("as_wkb() propagates geodesic", {
 test_that("examples as wkb roundtrip", {
   for (which in names(wk_example_wkt)) {
     expect_identical(
-      wk_handle(as_wkb(wk_example(!!which, crs = NULL)), wkb_writer()),
-      as_wkb(wk_example(!!which, crs = NULL))
+      wk_handle(as_wkb(wk_example(!!which, crs = NULL)), wkt_writer()),
+      wk_example(!!which, crs = NULL)
     )
   }
 })


### PR DESCRIPTION
Closes #196.

This adds about 0.5-1ms for every million points, which seems reasonable to me to improve consistency and enable round-tripping through WKB in more cases.