### PR TITLE
Patch wk_crs_projjson for GDAL < 3.1

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -20,6 +20,8 @@ jobs:
         config:
           # Checks gcc 4.8
           - {os: windows-latest, r: '3.6'}
+          # Checks gdal < 3.1
+          - {os: ubuntu-20.04, r: 'release'}
           - {os: macOS-latest,   r: 'release'}
           - {os: windows-latest, r: 'release'}
           - {os: ubuntu-latest,   r: 'devel', http-user-agent: 'release'}

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # wk (development version)
 
+- Fix `wk_crs_projjson()` for `crs` with GDAL < 3.1 (#212, #214)
+
 # wk 0.9.1
 
 - Fix format strings/arguments for R-devel (#209).

--- a/R/pkg-sf.R
+++ b/R/pkg-sf.R
@@ -138,7 +138,7 @@ wk_crs_proj_definition.crs <- function(crs, proj_version = NULL, verbose = FALSE
 #' @export
 wk_crs_projjson.crs <- function(crs) {
   json <- crs$ProjJson
-  if (is.null(json)) {
+  if (is.null(json) || is.na(json[1])) {
     # i.e., GDAL is not >= 3.1.0
     NextMethod()
   } else {


### PR DESCRIPTION
Fixes `wk_crs_projjson()` for `crs` objects when GDAL < 3.1.

Closes #212 