### PR TITLE
Fix build on arm64-windows

### DIFF
--- a/src/internal/fast_float/fast_float.h
+++ b/src/internal/fast_float/fast_float.h
@@ -304,7 +304,7 @@ fastfloat_really_inline uint64_t _umul128(uint64_t ab, uint64_t cd,
 fastfloat_really_inline value128 full_multiplication(uint64_t a,
                                                      uint64_t b) {
   value128 answer;
-#ifdef _M_ARM64
+#if defined(_M_ARM64) && !defined(_WIN32)
   // ARM64 has native support for 64-bit multiplications, no need to emulate
   answer.high = __umulh(a, b);
   answer.low = a * b;


### PR DESCRIPTION
The `__umulh` function is not available in our windows arm64 toolhain, so don't use it.