### PR TITLE
fix: wk_trans inconsistent meta flags handling

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,7 @@
 # wk (development version)
 
 - Add `wk_crs()` and `wk_set_crs()` methods for `bbox` (#213)
+- Fix wk_trans inconsistent meta flags handling (#217)
 
 # wk 0.9.1
 

--- a/src/transform.c
+++ b/src/transform.c
@@ -155,7 +155,7 @@ int wk_trans_filter_coord(const wk_meta_t* meta, const double* coord, uint32_t c
   } else if (meta->flags & WK_FLAG_HAS_Z) {
     trans_filter->xyzm_in[2] = coord[2];
     trans_filter->xyzm_in[3] = R_NaN;
-  } else if (new_meta->flags & WK_FLAG_HAS_M) {
+  } else if (meta->flags & WK_FLAG_HAS_M) {
     trans_filter->xyzm_in[2] = R_NaN;
     trans_filter->xyzm_in[3] = coord[2];
   } else {

--- a/tests/testthat/test-transform.R
+++ b/tests/testthat/test-transform.R
@@ -48,3 +48,73 @@ test_that("wk_transform_filter() errors when the recursion limit is too high", {
     "Too many recursive levels"
   )
 })
+
+test_that("wk_trans uses meta flags consistently", {
+  # from paleolimbot/wk#216
+  # NOTE: using wk_trans_set() because it exposes use_z and use_m parameters
+  #   we could equivalently use wk_trans_explicit()
+  
+  expect_identical(
+    wk_transform(
+      xy(1, 1),
+      wk_trans_set(xy(1, 1), use_z = TRUE)
+    ),
+    xyz(1, 1, NaN)
+  )
+
+  expect_identical(
+    wk_transform(
+      xy(1, 1),
+      wk_trans_set(xy(1, 1), use_m = TRUE)
+    ),
+    xym(1, 1, NaN)
+  )
+
+  expect_identical(
+    wk_transform(
+      xy(1, 1),
+      wk_trans_set(xy(1, 1), use_z = TRUE, use_m = TRUE)
+    ),
+    xyzm(1, 1, NaN, NaN)
+  )
+
+  expect_identical(
+    wk_transform(
+      xym(1, 1, 1),
+      wk_trans_set(xy(1, 1), use_z = TRUE)
+    ),
+    xyzm(1, 1, NaN, 1)
+  )
+
+  expect_identical(
+    wk_transform(
+      xyz(1, 1, 1),
+      wk_trans_set(xy(1, 1), use_m = TRUE)
+    ),
+    xyzm(1, 1, 1, NaN)
+  )
+
+  expect_identical(
+    wk_transform(
+      xyzm(1, 1, 1, 1),
+      wk_trans_set(xy(1, 1), use_z = TRUE)
+    ),
+    xyzm(1, 1, 1, 1)
+  )
+
+  expect_identical(
+    wk_transform(
+      xyzm(1, 1, 1, 1),
+      wk_trans_set(xy(1, 1), use_m = TRUE)
+    ),
+    xyzm(1, 1, 1, 1)
+  )
+
+  expect_identical(
+    wk_transform(
+      xyzm(1, 1, 1, 1),
+      wk_trans_set(xy(1, 1), use_z = TRUE, use_m = TRUE)
+    ),
+    xyzm(1, 1, 1, 1)
+  )
+})


### PR DESCRIPTION
Fixes wk_trans inconsistent meta flags handling, which can result in garbage values in the `m` dimension when input doesn't contain `m` dimension and `use_m = TRUE`.

Fixes #216