### PR TITLE
Fix windows ARM build

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -18,8 +18,6 @@ jobs:
       fail-fast: false
       matrix:
         config:
-          # Checks gcc 4.8
-          - {os: windows-latest, r: '3.6'}
           - {os: macOS-latest,   r: 'release'}
           - {os: windows-latest, r: 'release'}
           - {os: ubuntu-latest,   r: 'devel', http-user-agent: 'release'}

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,7 @@
 
 - Add `wk_crs()` and `wk_set_crs()` methods for `bbox` (#213)
 - Fix wk_trans inconsistent meta flags handling (#217)
+- Ensure package builds on arm64 for Windows (#220)
 
 # wk 0.9.1
 

--- a/src/internal/fast_float/fast_float.h
+++ b/src/internal/fast_float/fast_float.h
@@ -15,9 +15,9 @@
 // MIT License Notice
 //
 //    MIT License
-//    
+//
 //    Copyright (c) 2021 The fast_float authors
-//    
+//
 //    Permission is hereby granted, free of charge, to any
 //    person obtaining a copy of this software and associated
 //    documentation files (the "Software"), to deal in the
@@ -27,11 +27,11 @@
 //    the Software, and to permit persons to whom the Software
 //    is furnished to do so, subject to the following
 //    conditions:
-//    
+//
 //    The above copyright notice and this permission notice
 //    shall be included in all copies or substantial portions
 //    of the Software.
-//    
+//
 //    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
 //    ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
 //    TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
@@ -48,9 +48,9 @@
 //    Licensed under the Apache License, Version 2.0 (the "License");
 //    you may not use this file except in compliance with the License.
 //    You may obtain a copy of the License at
-//    
+//
 //    http://www.apache.org/licenses/LICENSE-2.0
-//    
+//
 //    Unless required by applicable law or agreed to in writing, software
 //    distributed under the License is distributed on an "AS IS" BASIS,
 //    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -304,7 +304,7 @@ fastfloat_really_inline uint64_t _umul128(uint64_t ab, uint64_t cd,
 fastfloat_really_inline value128 full_multiplication(uint64_t a,
                                                      uint64_t b) {
   value128 answer;
-#if defined(_M_ARM64) && !defined(_WIN32)
+#if defined(_M_ARM64) && defined(_MSC_VER)
   // ARM64 has native support for 64-bit multiplications, no need to emulate
   answer.high = __umulh(a, b);
   answer.low = a * b;
@@ -1495,9 +1495,9 @@ namespace detail {
  * where
  *   p = log(5**q)/log(2) = q * log(5)/log(2)
  *
- * For negative values of q in (-400,0), we have that 
+ * For negative values of q in (-400,0), we have that
  *  f = (((152170 + 65536) * q ) >> 16);
- * is equal to 
+ * is equal to
  *   -ceil(p) + q
  * where
  *   p = log(5**-q)/log(2) = -q * log(5)/log(2)
@@ -1568,7 +1568,7 @@ adjusted_mantissa compute_float(int64_t q, uint64_t w)  noexcept  {
     // In some very rare cases, this could happen, in which case we might need a more accurate
     // computation that what we can provide cheaply. This is very, very unlikely.
     //
-    const bool inside_safe_exponent = (q >= -27) && (q <= 55); // always good because 5**q <2**128 when q>=0, 
+    const bool inside_safe_exponent = (q >= -27) && (q <= 55); // always good because 5**q <2**128 when q>=0,
     // and otherwise, for q<0, we have 5**-q<2**64 and the 128-bit reciprocal allows for exact computation.
     if(!inside_safe_exponent) {
       return compute_error_scaled<binary>(q, product.high, lz);


### PR DESCRIPTION
From Tomas:

```
Dear Maintainer,

unfortunately your package cannot be built on Windows/aarch64, because it attempts to use a Microsoft intrinsic _umulh, which is not available with Rtools (non-Microsoft toolchain).

The fix is trivial, as attached, feel free to use the patch.

I am aware that your upstream version includes a different patch from Jeroen Ooms, claiming that it is a toolchain bug. That is not true, and my patch conditions on _MSC_VER, which I think is more correct.

But the difference is not critical, either way, please do submit a version that has a variant of the fix to CRAN. It would be great if you could do it, soon, as this is a trivial change but is needed for Windows/aarch64.
```