### PR TITLE
Avoid potential 0-length access in memcpy

### DIFF
--- a/src/vertex-filter.c
+++ b/src/vertex-filter.c
@@ -87,8 +87,10 @@ static inline void wk_vertex_filter_finalize_details(vertex_filter_t* vertex_fil
   if (vertex_filter->coord_id != vertex_filter->details_size) {
     for (int i = 0; i < 3; i++) {
       SEXP new_item = PROTECT(Rf_allocVector(INTSXP, vertex_filter->coord_id));
-      memcpy(INTEGER(new_item), INTEGER(VECTOR_ELT(vertex_filter->details, i)),
-             vertex_filter->coord_id * sizeof(int));
+      if (vertex_filter->coord_id > 0) {
+        memcpy(INTEGER(new_item), INTEGER(VECTOR_ELT(vertex_filter->details, i)),
+               vertex_filter->coord_id * sizeof(int));
+      }
       SET_VECTOR_ELT(vertex_filter->details, i, new_item);
       UNPROTECT(1);
     }

--- a/src/xy-writer.c
+++ b/src/xy-writer.c
@@ -50,11 +50,11 @@ static inline SEXP xy_writer_realloc_result(SEXP result, R_xlen_t new_size,
   }
 
   for (int i = 0; i < 4; i++) {
-    if (VECTOR_ELT(result, i) == R_NilValue) {
+    if (VECTOR_ELT(result, i) == R_NilValue || size_cpy == 0) {
       continue;
     }
 
-    memcpy(REAL(VECTOR_ELT(new_result, i)), REAL(VECTOR_ELT(result, i)),
+    memcpy(REAL(VECTOR_ELT(new_result, i)), REAL_RO(VECTOR_ELT(result, i)),
            sizeof(double) * size_cpy);
   }
 


### PR DESCRIPTION
Similar discovery as https://github.com/r-lib/vctrs/pull/1968

Both of these sites triggered segfaults for me from running:

```r
s2::s2_plot(s2::s2_data_countries())
```